### PR TITLE
Introduce extending third-party models

### DIFF
--- a/concepts/ORM/Models.md
+++ b/concepts/ORM/Models.md
@@ -276,6 +276,51 @@ Person.marry([joe,raquel], function (err) {
 ###### Naming your attribute methods
 Make sure you use a naming convention that helps you avoid confusing **attribute methods** from _attribute values_ when you're working with records in your app.  A good best practice is to use "get*" (e.g. `getFullName()`) prefix and avoid writing attribute methods that change records in-place.
 
+### Extending models
+
+Packages can introduce their own models with prebuilt properties and methods that our app's models can extend. If a package exposes a model in an Npm package,
+
+```javascript
+// otherApp/api/models/Person.js
+module.exports = {
+  attributes: {
+    firstName: {
+      type: 'string'
+    },
+    lastName: {
+      type: 'string'
+    },
+  }
+};
+```
+
+```javascript
+// myapp/api/models/PetOwner.js
+
+// Lodash's `.extend` method is useful for this senario;
+// see http://underscorejs.org/#extend for the docs
+let _ = require('lodash');
+
+// Import the model from the otherApp package
+let Person = require('otherApp/api/models/Person');
+
+// Pet owners get properties and methods specific to them
+let PetOwner = {
+  attributes: {
+    pets: {
+      collection: "pet",
+      via: "owner",
+    },
+    // Pet owners can give commands to their pets
+    issueCommand: function(order) {
+      return `${this.firstName} says ${order}!`;
+    }
+  }
+};
+
+module.exports = _.extend(PetOwner, Person);
+```
+
 <!--
 
 Imagine you have a small monkey named Timothy that rides on your shoulders and styles your hair when you are scheduled to speak at a conference.  In this scenario, you are a record of the `Person` model and Timothy is a record of the `Monkey` model. The `Person` model has primitive attributes like "name", "email", and "phoneNumber", and relational attributes like "petMonkey" (points to an individual `Monkey`) and "mom" (points to an individual `Person`).  Meanwhile the `Monkey` model has primitive attributes "name", "age", and "demeanor", as well as an relational attribute: "petOfPerson" (which points to an individual person).


### PR DESCRIPTION
This commit explains how to extend a third-party packages' model to extend into your own. This is particularly useful for the package sails-auth, which doesn't intuitively explain that it's models can me extended.
